### PR TITLE
Fixes build process running out of JVM heap space

### DIFF
--- a/APDE/build.gradle
+++ b/APDE/build.gradle
@@ -33,7 +33,7 @@ android {
     }
 
     dexOptions {
-        incremental true
+//        incremental true
         preDexLibraries = false
         javaMaxHeapSize "2048M"
 //        javaMaxHeapSize "4g"

--- a/APDE/build.gradle
+++ b/APDE/build.gradle
@@ -2,11 +2,10 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.calsignlabs.apde"
-        minSdkVersion 17
+        minSdkVersion 19
         targetSdkVersion 27
         versionCode 31
         versionName "0.5.1"
@@ -34,7 +33,10 @@ android {
     }
 
     dexOptions {
-        javaMaxHeapSize "4g"
+        incremental true
+        preDexLibraries = false
+        javaMaxHeapSize "2048M"
+//        javaMaxHeapSize "4g"
     }
 
     sourceSets { main { res.srcDirs = ['src/main/res'] } }
@@ -42,28 +44,28 @@ android {
 
 dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    compile project(':aFileChooser')
-    compile files('libs/android-core.jar')
-    compile files('libs/antlr.jar')
-    compile files('libs/core-1.51.0.0.jar')
-    compile files('libs/dx.jar')
-    compile files('libs/ecj.jar')
-    compile files('libs/JavaMode.jar')
-    compile files('libs/jsch-0.1.51.jar')
-    compile files('libs/kellinwood-logging-android-1.4.jar')
-    compile files('libs/kellinwood-logging-lib-1.1.jar')
-    compile files('libs/org.eclipse.jgit-3.5.2.201411120430-r.jar')
-    compile files('libs/pde.jar')
-    compile files('libs/pkix-1.51.0.0.jar')
-    compile files('libs/prov-1.51.0.0.jar')
-    compile files('libs/sdklib.jar')
-    compile files('libs/zipio-lib-1.8.jar')
-    compile files('libs/zipsigner-lib-1.17.jar')
-    compile files('libs/zipsigner-lib-optional-1.17.jar')
-    compile 'com.android.support:support-v4:27.0.1'
-    compile 'com.android.support:appcompat-v7:27.0.1'
-    compile 'com.android.support:design:27.0.1'
-    compile 'com.takisoft.fix:preference-v7:27.0.1.0'
-    compile 'com.google.android.gms:play-services-auth:15.0.1'
+    implementation project(':aFileChooser')
+    implementation files('libs/android-core.jar')
+    implementation files('libs/antlr.jar')
+    implementation files('libs/core-1.51.0.0.jar')
+    implementation files('libs/dx.jar')
+    implementation files('libs/ecj.jar')
+    implementation files('libs/JavaMode.jar')
+    implementation files('libs/jsch-0.1.51.jar')
+    implementation files('libs/kellinwood-logging-android-1.4.jar')
+    implementation files('libs/kellinwood-logging-lib-1.1.jar')
+    implementation files('libs/org.eclipse.jgit-3.5.2.201411120430-r.jar')
+    implementation files('libs/pde.jar')
+    implementation files('libs/pkix-1.51.0.0.jar')
+    implementation files('libs/prov-1.51.0.0.jar')
+    implementation files('libs/sdklib.jar')
+    implementation files('libs/zipio-lib-1.8.jar')
+    implementation files('libs/zipsigner-lib-1.17.jar')
+    implementation files('libs/zipsigner-lib-optional-1.17.jar')
+    implementation 'com.android.support:support-v4:27.0.1'
+    implementation 'com.android.support:appcompat-v7:27.0.1'
+    implementation 'com.android.support:design:27.0.1'
+    implementation 'com.takisoft.fix:preference-v7:27.0.1.0'
+    implementation 'com.google.android.gms:play-services-auth:15.0.1'
     implementation 'com.google.android.gms:play-services-wearable:15.0.1'
 }

--- a/aFileChooser/build.gradle
+++ b/aFileChooser/build.gradle
@@ -2,11 +2,10 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 25
+        minSdkVersion 19
+        targetSdkVersion 26
     }
 
     buildTypes {
@@ -18,5 +17,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:27.0.1'
+    implementation 'com.android.support:support-v4:27.0.1'
 }

--- a/aFileChooser/src/main/AndroidManifest.xml
+++ b/aFileChooser/src/main/AndroidManifest.xml
@@ -17,6 +17,4 @@
  <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.ipaulpro.afilechooser">
 
-    <uses-sdk android:minSdkVersion="7" />
-
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.5.1'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.daemon=true
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/sketch-preview/build.gradle
+++ b/sketch-preview/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
 
     defaultConfig {
         applicationId "com.calsignlabs.apde.sketchpreview"
-        minSdkVersion 17
-        targetSdkVersion 25
+        minSdkVersion 19
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 
@@ -23,6 +23,6 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.android.support:appcompat-v7:25.3.1'
-    compile files('libs/android-core.jar')
+    implementation 'com.android.support:appcompat-v7:26.0.1'
+    implementation files('libs/android-core.jar')
 }

--- a/sketch-preview/src/main/AndroidManifest.xml
+++ b/sketch-preview/src/main/AndroidManifest.xml
@@ -3,9 +3,7 @@
 	package="com.calsignlabs.apde.sketchpreview"
 	android:versionCode="1"
 	android:versionName="1.0">
-	
-	<uses-sdk android:minSdkVersion="17" android:targetSdkVersion="26" />
-	
+
 	<!-- These ones are innocuous -->
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/wear-companion/build.gradle
+++ b/wear-companion/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'com.android.support:support-v4:27.1.1'
     implementation 'com.android.support:recyclerview-v7:27.1.1'
     implementation 'com.android.support:wear:27.1.1'
-    compileOnly 'com.google.android.wearable:wearable:2.3.0'
+    implementation 'com.google.android.wearable:wearable:2.3.0'
 
     implementation files('libs/processing-core.jar')
 }


### PR DESCRIPTION
It sets some JVM arguments in the gradle.properties file and in the dexOptions in the build file, according to [this post](https://stackoverflow.com/a/36695880).

It also replaces the compile directive by implementation, since Gradle deprecated the former, and bumps the version of some dependencies.