### PR TITLE
Some crutch to fix .java compilation

### DIFF
--- a/APDE/src/main/java/com/calsignlabs/apde/BareSketchFile.java
+++ b/APDE/src/main/java/com/calsignlabs/apde/BareSketchFile.java
@@ -20,7 +20,11 @@ public abstract class BareSketchFile {
 	 * @return the filename as it is saved (name + suffix)
 	 */
 	public String getFilename() {
-		return getTitle() + getSuffix();
+		if(getSuffix().equalsIgnoreCase(".java")&&getTitle().endsWith(getSuffix())) {
+			return getTitle();
+		} else {
+			return getTitle() + getSuffix();
+		}
 	}
 	
 	public boolean isPde() {


### PR DESCRIPTION
Some crutch to fix Calsign/APDE/#95
Seems to work. Probably fix shoud be located in [SketchFile.java::getTitle()](https://github.com/Calsign/APDE/blob/9026cb0125fd322c69eb4c212597769735bafe32/APDE/src/main/java/com/calsignlabs/apde/SketchFile.java#L438)

